### PR TITLE
Add VC++ 2012 runtime autoinstall

### DIFF
--- a/build/install-vc2012.ps1
+++ b/build/install-vc2012.ps1
@@ -1,0 +1,9 @@
+$arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
+$urls = @{ 
+  x86 = "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe"
+  x64 = "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe"
+}
+$temp = Join-Path $env:TEMP "vc2012_$arch.exe"
+Invoke-WebRequest $urls[$arch] -OutFile $temp
+Start-Process -FilePath $temp -ArgumentList '/install','/quiet','/norestart' -Wait
+Remove-Item $temp

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,6 @@
+!macro customInstall
+  SetOutPath "$INSTDIR"
+  File "..\build\install-vc2012.ps1"
+  nsExec::ExecToLog '"$WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -NoProfile -File "$INSTDIR\install-vc2012.ps1"'
+  Delete "$INSTDIR\install-vc2012.ps1"
+!macroend

--- a/vue.config.js
+++ b/vue.config.js
@@ -36,6 +36,9 @@ module.exports = defineConfig({
           signAndEditExecutable: true,
           verifyUpdateCodeSignature: false
         },
+        nsis: {
+          include: "build/installer.nsh"
+        },
         extraResources: [
           {
             from: "./extraResources/",


### PR DESCRIPTION
## Summary
- automatically install VC++ 2012 runtime during setup

## Testing
- `yarn test:unit` *(fails: Electron failed to install)*

------
https://chatgpt.com/codex/tasks/task_e_6880057d16cc8324a280d872a6e70213