### PR TITLE
Fix path to VC runtime script in NSIS installer

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,6 +1,6 @@
 !macro customInstall
   SetOutPath "$INSTDIR"
-  File "..\build\install-vc2012.ps1"
+  File "${BUILD_RESOURCES_DIR}\install-vc2012.ps1"
   nsExec::ExecToLog '"$WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" -ExecutionPolicy Bypass -NoProfile -File "$INSTDIR\install-vc2012.ps1"'
   Delete "$INSTDIR\install-vc2012.ps1"
 !macroend


### PR DESCRIPTION
## Summary
- fix NSIS script to locate install-vc2012.ps1 using BUILD_RESOURCES_DIR macro

## Testing
- `yarn install` *(fails: Maximum number of redirects exceeded)*
- `yarn test:unit` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879777f4a08324a5151f38d31b90e5