### PR TITLE
Enhance quiz eye tracking support

### DIFF
--- a/src/frontend/components/EditorView/SetSettings.vue
+++ b/src/frontend/components/EditorView/SetSettings.vue
@@ -65,9 +65,10 @@
           />
           <section v-if="isQuiz">
             <v-card-subtitle> Настройки викторины </v-card-subtitle>
-            <v-checkbox
+            <v-select
               v-model="editor_quizAutoNext"
-              label="Переключать на следующий вопрос при любом ответе"
+              :items="quizModeItems"
+              label="Режим викторины"
             />
             <v-checkbox
               v-model="editor_quizReadQuestion"
@@ -154,6 +155,11 @@ const editor_quizAutoNext = computed({
     store.commit("editor_quizAutoNext", v);
   }
 });
+
+const quizModeItems = [
+  { title: "Режим оценки", value: true },
+  { title: "Режим практики", value: false }
+];
 </script>
 
 <style>

--- a/src/frontend/components/QuizOutputLine.vue
+++ b/src/frontend/components/QuizOutputLine.vue
@@ -42,21 +42,12 @@
           <v-card-text> Хотите начать сначала? </v-card-text>
           <v-card-actions>
             <v-spacer />
-            <v-btn
-              color="green darken-1"
-              @click="
-                emit('restart'),
-                endDialog = false
-              "
-            >
+            <eye-button class="gaze-btn" color="green" @click="emit('restart'); endDialog = false">
               Да
-            </v-btn>
-            <v-btn
-              color="green darken-1"
-              @click="endDialog = false"
-            >
+            </eye-button>
+            <eye-button class="gaze-btn" color="green" @click="endDialog = false">
               Нет
-            </v-btn>
+            </eye-button>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -68,12 +59,9 @@
           <v-card-text> Вам будут предложены вопросы, выбирайте ответы </v-card-text>
           <v-card-actions>
             <v-spacer />
-            <v-btn
-              color="green darken-1"
-              @click="startDialog = false"
-            >
+            <eye-button class="gaze-btn" color="green" @click="startDialog = false">
               Начать
-            </v-btn>
+            </eye-button>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -86,6 +74,7 @@ import { defineProps, defineEmits, computed, ref, watch } from "vue";
 import { useStore } from "vuex";
 import type { ConfigFile } from "@/common/interfaces/ConfigFile";
 import { TTS } from "@/frontend/utils/TTS";
+import EyeButton from "@/frontend/components/EyeButton.vue";
 
 interface IQuizOutputLineProps {
   config: ConfigFile
@@ -156,5 +145,11 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.gaze-btn {
+  width: 200px;
+  height: 100px;
+  font-size: 1.2em;
+  margin: 0.5em;
 }
 </style>

--- a/src/frontend/views/SetExplorerView.vue
+++ b/src/frontend/views/SetExplorerView.vue
@@ -5,6 +5,7 @@
     class="root"
     :class="{ root_hide: !interfaceOutputLine && !isQuiz && !isSettingsOpened, root_settings: isSettingsOpened}"
   >
+    <div v-if="processing" class="answer-overlay" />
     <layout-settings-panel></layout-settings-panel>
     <output-line
       v-if="interfaceOutputLine && !isQuiz && !isSettingsOpened"
@@ -45,6 +46,7 @@ import SetGrid from "@/frontend/components/SetGrid.vue";
 import { CardType, type Card } from "@/common/interfaces/ConfigFile";
 import { TTS } from "@/frontend/utils/TTS";
 import { Metric } from "@/frontend/utils/Metric";
+import { storageService } from "@/frontend/services/card-storage-service";
 import LayoutSettingsPanel from "../components/LayoutSettingsPanel.vue";
 
 const store = useStore();
@@ -54,6 +56,7 @@ const filename: Ref<string | null> = ref(null);
 const cards: Ref<Card[]> = ref([]);
 const quizPage = ref(0);
 const errors = ref(0);
+const processing = ref(false);
 
 onMounted(() => {
   filename.value = route.params.path.toString();
@@ -89,6 +92,16 @@ function addCard (card: Card) {
   Metric.registerEvent(store.state.pcHash, "cardClick", { card });
   if (isQuiz.value) {
     const voice = store.state.voice;
+    processing.value = true;
+    store.commit("button_enabled", false);
+    setTimeout(() => {
+      processing.value = false;
+      store.commit("button_enabled", true);
+    }, 1500);
+    if (Math.random() < 0.5 && card.title && filename.value) {
+      storageService.createAudioFromText(filename.value, card.title, voice).catch(console.error);
+      TTS.instance.playText(card.title, voice).catch(console.error);
+    }
     if (card.answer) {
       TTS.instance.playText("Правильный ответ", voice).catch(console.error);
       quizPage.value++;
@@ -128,5 +141,14 @@ function addCard (card: Card) {
 .root > div {
   /* border: 1px solid black; */
   width: 100%;
+}
+.answer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
 }
 </style>


### PR DESCRIPTION
## Summary
- use EyeButton in quiz start and end dialogs so large buttons work with gaze
- dim screen and lock gaze input briefly after answering
- play answer aloud randomly and store audio via TTS
- show practice vs evaluation mode selector in set settings

## Testing
- `yarn lint`
- `yarn test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688809cfd0808324a1693f166a5ddc85