### PR TITLE
chore: release 3.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linka.looks",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linka.looks",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "hasInstallScript": true,
       "dependencies": {
         "@linkasu/tobii-electron": "https://github.com/linkasu/linka-tobii-electron/releases/download/v0.2.16/linkasu-tobii-electron-0.2.16.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linka.looks",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "author": "ibakaidov",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Release
- publish LINKa Looks 3.2.9
- include merged consent-first Identity V2 telemetry

## Verification
- npm ci under Node 22.22.2
- npm run lint
- npm run typecheck
- npm run test:unit (114 tests)