### PR TITLE
feat: copy audio between cards

### DIFF
--- a/src/frontend/tests/unit/editorLogic.spec.ts
+++ b/src/frontend/tests/unit/editorLogic.spec.ts
@@ -2,9 +2,11 @@ import chai from "chai";
 import { Card, CardType, normalizePage } from "@/common/interfaces/ConfigFile";
 import {
   advanceEditorPage,
+  applyCardAudio,
   canMergeSelectedCard,
   clearCardAudio,
   clearMatchLink,
+  copyCardAudio,
   copyEditorPage,
   copySelectedCard,
   createEditorPage,
@@ -64,6 +66,66 @@ describe("editorLogic", () => {
     expect(result.title).to.equal("one");
     expect(result.imagePath).to.equal("one.png");
     expect(card.audioPath).to.equal("voice.mp3");
+  });
+
+  it("copies all available audio data without changing the source card", () => {
+    const source: Card = {
+      id: "source",
+      cardType: CardType.AudioCard,
+      title: "Дом",
+      audioPath: "voice.mp3",
+      audioText: "дом",
+      audioVoice: "alena"
+    };
+
+    const copied = copyCardAudio(source);
+
+    expect(copied).to.deep.equal({
+      audioPath: "voice.mp3",
+      audioText: "дом",
+      audioVoice: "alena"
+    });
+    expect(source).to.deep.equal({
+      id: "source",
+      cardType: CardType.AudioCard,
+      title: "Дом",
+      audioPath: "voice.mp3",
+      audioText: "дом",
+      audioVoice: "alena"
+    });
+  });
+
+  it("does not copy a card without audio", () => {
+    expect(copyCardAudio({ id: "empty", cardType: CardType.AudioCard })).to.equal(null);
+  });
+
+  it("applies copied audio and clears stale text-to-speech data", () => {
+    const target: Card = {
+      id: "target",
+      cardType: CardType.AudioCard,
+      title: "Кошка",
+      imagePath: "cat.png",
+      answer: true,
+      audioPath: "old.mp3",
+      audioText: "кошка",
+      audioVoice: "john"
+    };
+
+    const result = applyCardAudio(target, { audioPath: "copied.wav" });
+
+    expect(result).to.deep.include({
+      id: "target",
+      cardType: CardType.AudioCard,
+      title: "Кошка",
+      imagePath: "cat.png",
+      answer: true,
+      audioPath: "copied.wav"
+    });
+    expect(result.audioText).to.equal(undefined);
+    expect(result.audioVoice).to.equal(undefined);
+    expect(target.audioPath).to.equal("old.mp3");
+    expect(target.audioText).to.equal("кошка");
+    expect(target.audioVoice).to.equal("john");
   });
 
   it("copies selected card after itself and removes last placeholder", () => {

--- a/src/frontend/utils/editorLogic.ts
+++ b/src/frontend/utils/editorLogic.ts
@@ -17,6 +17,12 @@ export interface EditorCardsResult {
   selectedCardId: string | null;
 }
 
+export interface CardAudio {
+  audioPath: string;
+  audioText?: string;
+  audioVoice?: string;
+}
+
 export interface EditorPagesResult {
   pages: SetPage[];
   page: number;
@@ -76,6 +82,23 @@ export function clearCardAudio (card: Card): Card {
   delete next.audioPath;
   delete next.audioText;
   delete next.audioVoice;
+  return next;
+}
+
+export function copyCardAudio (card: Card): CardAudio | null {
+  if (!card.audioPath) return null;
+  return {
+    audioPath: card.audioPath,
+    audioText: card.audioText,
+    audioVoice: card.audioVoice
+  };
+}
+
+export function applyCardAudio (card: Card, audio: CardAudio): Card {
+  const next = clearCardAudio(card);
+  next.audioPath = audio.audioPath;
+  if (audio.audioText !== undefined) next.audioText = audio.audioText;
+  if (audio.audioVoice !== undefined) next.audioVoice = audio.audioVoice;
   return next;
 }
 

--- a/src/frontend/views/EditorView.vue
+++ b/src/frontend/views/EditorView.vue
@@ -1,6 +1,25 @@
 <template>
   <div fluid class="editor">
     <new-file-dialog :show="newFileDialogShow" :disabled="ui_disabled" @text="newFileName" />
+    <v-dialog v-model="audioOverwriteDialog" max-width="420">
+      <v-card>
+        <v-card-title>Заменить озвучку?</v-card-title>
+        <v-card-text>
+          На выбранной карточке уже есть озвучка. Заменить её скопированной?
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="audioOverwriteDialog = false">Отмена</v-btn>
+          <v-btn color="primary" @click="pasteCopiedAudio">Заменить</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-snackbar v-model="audioNotificationVisible" :timeout="3000">
+      {{ audioNotification }}
+      <template #actions>
+        <v-btn variant="text" @click="audioNotificationVisible = false">Закрыть</v-btn>
+      </template>
+    </v-snackbar>
     <div class="editor-body">
       <v-card v-if="filename" xs8 fill-height fluid>
         <v-card-title> Карточки </v-card-title>
@@ -213,6 +232,25 @@
                           Выбрать звук из файла
                         </v-btn>
                       </v-row>
+                      <v-row>
+                        <v-col>
+                          <v-btn block :disabled="ui_disabled || !selected.audioPath" @click="copyAudio">
+                            <v-icon start>mdi-content-copy</v-icon>
+                            Копировать озвучку
+                          </v-btn>
+                        </v-col>
+                        <v-col>
+                          <v-btn block color="primary" :disabled="ui_disabled || !canPasteAudio" @click="requestPasteAudio">
+                            <v-icon start>mdi-content-paste</v-icon>
+                            Вставить озвучку
+                          </v-btn>
+                        </v-col>
+                      </v-row>
+                      <v-row>
+                        <div class="audio-copy-hint">
+                          {{ audioCopyHint }}
+                        </div>
+                      </v-row>
                       <v-row v-if="selected.audioPath">
                         <v-col>
                           <v-btn block :disabled="ui_disabled" @click="playAudio">
@@ -304,8 +342,10 @@ import draggable from "vuedraggable";
 import { Telemetry } from "@/frontend/utils/Telemetry";
 import {
   advanceEditorPage,
+  applyCardAudio,
   clearCardAudio,
   clearMatchLink as clearEditorMatchLink,
+  copyCardAudio,
   copySelectedCard,
   createEditorPage,
   getSelectedCardSpanInfo,
@@ -325,6 +365,10 @@ const route = useRoute();
 const newFileDialogShow = ref(false);
 const selectedCardId = ref<string | null>(null);
 const pendingMatchCardId = ref<string | null>(null);
+const copiedAudio = ref<{ sourceCardId: string, sourceTitle: string, audioPath: string, audioText?: string, audioVoice?: string } | null>(null);
+const audioOverwriteDialog = ref(false);
+const audioNotification = ref("");
+const audioNotificationVisible = ref(false);
 
 onMounted(() => {
   if (route.params.path.toString().endsWith("new")) {
@@ -457,6 +501,15 @@ const selectedIndex = computed(() => current.value.findIndex((card) => card.id =
 const selected = computed<Card | null>(() => {
   if (selectedIndex.value === -1) return null;
   return current.value[selectedIndex.value] ?? null;
+});
+
+const canPasteAudio = computed(() => {
+  return !!copiedAudio.value && copiedAudio.value.sourceCardId !== selected.value?.id;
+});
+
+const audioCopyHint = computed(() => {
+  if (!copiedAudio.value) return "Скопируйте озвучку, затем выберите другую карточку.";
+  return `Скопировано из карточки: ${copiedAudio.value.sourceTitle}`;
 });
 
 const selectedLane = computed(() => {
@@ -664,6 +717,39 @@ function clearAudio () {
   replaceSelected(clearCardAudio(selected.value));
 }
 
+function copyAudio () {
+  if (!selected.value) return;
+  const audio = copyCardAudio(selected.value);
+  if (!audio) return;
+  copiedAudio.value = {
+    ...audio,
+    sourceCardId: selected.value.id,
+    sourceTitle: selected.value.title || "без названия"
+  };
+  showAudioNotification(`Озвучка карточки «${copiedAudio.value.sourceTitle}» скопирована`);
+}
+
+function requestPasteAudio () {
+  if (!canPasteAudio.value || !selected.value) return;
+  if (selected.value.audioPath) {
+    audioOverwriteDialog.value = true;
+    return;
+  }
+  pasteCopiedAudio();
+}
+
+function pasteCopiedAudio () {
+  if (!canPasteAudio.value || !selected.value || !copiedAudio.value) return;
+  replaceSelected(applyCardAudio(selected.value, copiedAudio.value));
+  audioOverwriteDialog.value = false;
+  showAudioNotification("Озвучка вставлена");
+}
+
+function showAudioNotification (message: string) {
+  audioNotification.value = message;
+  audioNotificationVisible.value = true;
+}
+
 function replaceSelected (card: Card) {
   if (selectedIndex.value === -1) return;
   const nextCards = [...current.value];
@@ -772,5 +858,11 @@ function clearMatchLink () {
 
 .mb-2 {
   margin-bottom: 8px;
+}
+
+.audio-copy-hint {
+  font-size: 14px;
+  opacity: 0.75;
+  padding: 0 12px;
 }
 </style>


### PR DESCRIPTION
## Что изменено
- Добавлено копирование озвучки между карточками и страницами одного открытого набора.
- При замене существующей озвучки редактор запрашивает подтверждение.
- Вставка переносит путь к аудио и TTS-метаданные, не меняя остальные свойства карточки.

## Проверка
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run build