### PR TITLE
chore: release 3.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linka.looks",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linka.looks",
-      "version": "3.2.9",
+      "version": "3.2.10",
       "hasInstallScript": true,
       "dependencies": {
         "@linkasu/tobii-electron": "https://github.com/linkasu/linka-tobii-electron/releases/download/v0.2.16/linkasu-tobii-electron-0.2.16.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linka.looks",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "author": "ibakaidov",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Релиз
- выпуск LINKa. смотри 3.2.10
- добавлено копирование озвучки между карточками и страницами одного набора

## Проверка
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run build
- проверки PR на Windows и macOS